### PR TITLE
amend micro trend pre-survey period to revert to lowest observed compliance

### DIFF
--- a/R/functions.R
+++ b/R/functions.R
@@ -8374,11 +8374,11 @@ fit_survey_gam <- function(
   ci_50_hi <- pred$fit + (quantile75 * pred$se.fit)
   ci_50_lo <- pred$fit - (quantile75 * pred$se.fit)
   
-  fitted <- m$family$linkinv(pred$fit) * pred_dat$distancing
-  ci_90_hi <- m$family$linkinv(ci_90_hi) * pred_dat$distancing
-  ci_90_lo <- m$family$linkinv(ci_90_lo) * pred_dat$distancing
-  ci_50_hi <- m$family$linkinv(ci_50_hi) * pred_dat$distancing
-  ci_50_lo <- m$family$linkinv(ci_50_lo) * pred_dat$distancing
+  fitted <- m$family$linkinv(pred$fit) * pred_dat$distancing + pred_dat$distancing2
+  ci_90_hi <- m$family$linkinv(ci_90_hi) * pred_dat$distancing + pred_dat$distancing2
+  ci_90_lo <- m$family$linkinv(ci_90_lo) * pred_dat$distancing + pred_dat$distancing2
+  ci_50_hi <- m$family$linkinv(ci_50_hi) * pred_dat$distancing + pred_dat$distancing2
+  ci_50_lo <- m$family$linkinv(ci_50_lo) * pred_dat$distancing + pred_dat$distancing2
   
   
   

--- a/R/microdistancing_change.R
+++ b/R/microdistancing_change.R
@@ -15,6 +15,29 @@ survey_distance <- data$survey_distance
 pred_data <- data$prediction_data #%>%
   #mutate(date_num = as.numeric(date_num))
 
+# pred_plot %>%
+#   filter(
+#     date > min(survey_distance$date),
+#     date < max(survey_distance$date)
+#   ) %>%
+#   filter(
+#     mean == min(mean)
+#   ) %>%
+#   pull(mean)
+
+# use the lowest modelled compliance proportion (WA on Jan 30th)
+# to get the value to add to the pre-survey period to impute the trend
+min_observed <- 0.16
+pred_data <- pred_data %>%
+  mutate(
+    distancing2 = (1 - distancing) * min_observed
+  )
+  
+range(pred_data$distancing2)
+
+
+# mess with distancing effect in pred_data
+# set to lowest observed distancing metric (relative to highest) in any state
 
 
 min_date <- min(survey_distance$date)
@@ -86,7 +109,8 @@ df_fit <- survey_distance %>%
       count,
       respondents,
       intervention_stage,
-      distancing
+      distancing,
+      distancing2
     )
   )
 
@@ -117,13 +141,15 @@ df_pred <- pred_data %>%
     state,
     date,
     intervention_stage,
-    distancing
+    distancing,
+    distancing2
   ) %>%
   nest(
     pred_dat = c(
       date,
       intervention_stage,
-      distancing
+      distancing,
+      distancing2
     )
   )
 


### PR DESCRIPTION
Here's the tweak to change the micro baseline to the lowest observed compliance (C. 16% in WA Jan 30 2021) rather than 0%, to put a lower bound on the degree that behaviour has changed.

Rather than merging as is, if you push a new branch for this distancing baseline scenario model run, you should be able to change the base branch for this PR to that.